### PR TITLE
Update auto3dseg_segresnet_inference.py

### DIFF
--- a/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
+++ b/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
@@ -95,7 +95,6 @@ def main(model_file='model.pt',  image_file=None,  result_file = 'result.nii.gz'
         print('Using crop_foreground')
         ts.append(CropForegroundd(keys="image", source_key="image", margin=10, allow_smaller=True)) #subcrop
 
-    resample = True
     if config.get("resample_resolution", None) is not None:
         pixdim = list(config["resample_resolution"])
         print(f'Using resample with  resample_resolution {pixdim}')

--- a/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
+++ b/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
@@ -74,7 +74,6 @@ def main(model_file='model.pt',  image_file=None,  result_file = 'result.nii.gz'
     model = ConfigParser(config["network"]).get_parsed_content()
     model.load_state_dict(state_dict, strict=True)
 
-    print(str(model))
     print(f'Model epoch {epoch} metric {best_metric}')
 
 
@@ -96,9 +95,8 @@ def main(model_file='model.pt',  image_file=None,  result_file = 'result.nii.gz'
         print('Using crop_foreground')
         ts.append(CropForegroundd(keys="image", source_key="image", margin=10, allow_smaller=True)) #subcrop
 
-    resample = False #resample (optionally)
-    if config.get("resample", False) and config.get("resample_resolution", None) is not None:
-        resample = True
+    resample = True
+    if config.get("resample_resolution", None) is not None:
         pixdim = list(config["resample_resolution"])
         print(f'Using resample with  resample_resolution {pixdim}')
 


### PR DESCRIPTION
In the previous version, we didn't make sure the inference ran on the same spacing the model was trained on. That was the reason for poor performance.

Here are the updated results:


![CTChest](https://github.com/lassoan/SlicerMONAIAuto3DSeg/assets/11991079/9c43393c-74f1-4fb8-b726-86a6e20c3dfb)
![Panomarix-Spine](https://github.com/lassoan/SlicerMONAIAuto3DSeg/assets/11991079/a35eeba1-73ea-434c-8ed7-96eb2807daab)
![CTChest-Spine](https://github.com/lassoan/SlicerMONAIAuto3DSeg/assets/11991079/07853dbe-bae9-4eae-b37b-fb31a7f8da9f)
![Panomarix](https://github.com/lassoan/SlicerMONAIAuto3DSeg/assets/11991079/fe5c9822-8f28-4be4-8c0c-203e94734604)
