### PR TITLE
Add OpenVINO model inference when models are run on CPU

### DIFF
--- a/MONAIAuto3DSeg/MONAIAuto3DSeg.py
+++ b/MONAIAuto3DSeg/MONAIAuto3DSeg.py
@@ -1074,6 +1074,7 @@ class MONAIAuto3DSegLogic(ScriptedLoadableModuleLogic):
         if upgrade:
             monaiInstallString += " --upgrade"
         slicer.util.pip_install(monaiInstallString)
+        slicer.util.pip_install("openvino")
 
         self.dependenciesInstalled = True
         self.log("Dependencies are set up successfully.")

--- a/MONAIAuto3DSeg/MONAIAuto3DSeg.py
+++ b/MONAIAuto3DSeg/MONAIAuto3DSeg.py
@@ -246,6 +246,9 @@ class MONAIAuto3DSegWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.updateGUIFromParameterNode()
 
+        # Make the model search box in focus by default so users can just start typing to find the model they need
+        qt.QTimer.singleShot(0, self.ui.modelSearchBox.setFocus)
+
     def cleanup(self):
         """
         Called when the application closes and the module widget is destroyed.

--- a/MONAIAuto3DSeg/Resources/Models.json
+++ b/MONAIAuto3DSeg/Resources/Models.json
@@ -51,7 +51,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-organs-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/v0.0.1/abdominal-organs-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 95.3,

--- a/MONAIAuto3DSeg/Resources/Models.json
+++ b/MONAIAuto3DSeg/Resources/Models.json
@@ -10,7 +10,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-organs-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-organs-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 64.6,
@@ -51,7 +51,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/v0.0.1/abdominal-organs-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-organs-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 95.3,
@@ -92,7 +92,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/body-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/body-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 37.6,
@@ -112,7 +112,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/body-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/body-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 40.7,
@@ -132,10 +132,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-3mm-v2.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-3mm-v2.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 41.0,
@@ -179,10 +179,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-v2.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-v2.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/vertebrae-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 62.4,
@@ -226,13 +226,13 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.2.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.2.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 109.1,
@@ -273,7 +273,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/mediastinal-anatomy-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 45.3,
@@ -317,7 +317,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-head-05mm-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-head-05mm-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 64.6,
@@ -350,7 +350,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-head-1mm-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-head-1mm-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 30,
@@ -377,10 +377,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v1.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v1.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 201.9,
@@ -502,7 +502,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-3mm-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-3mm-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 82.3,
@@ -624,10 +624,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v2.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v2.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 49.5,
@@ -762,7 +762,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/whole-body-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 74.5,
@@ -897,19 +897,19 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.4.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.4.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.3.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.3.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.2.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.2.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.1.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.1.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/abdominal-17-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 83.5,
@@ -955,10 +955,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/prostate-v1.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/prostate-v1.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/prostate-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/prostate-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 30.8,
@@ -978,7 +978,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/ribs-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/ribs-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 45.5,
@@ -1022,7 +1022,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/ribs-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/ribs-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 66.2,
@@ -1066,7 +1066,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/muscles-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/muscles-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 60.5,
@@ -1107,7 +1107,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/muscles-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/muscles-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 88.5,
@@ -1148,7 +1148,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/cardiac-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/cardiac-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 42.9,
@@ -1184,7 +1184,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/cardiac-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/cardiac-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 95.6,
@@ -1220,7 +1220,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-3mm-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-3mm-v2.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 37.5,
@@ -1245,19 +1245,19 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v2.0.1.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v2.0.1.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v2.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v2.0.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.2.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.2.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.1.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.1.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/lungs-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 25.5,
@@ -1284,13 +1284,13 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.2.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.2.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.1.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.1.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/hips-and-spine-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 86.9,
@@ -1335,10 +1335,10 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/aorta-v1.1.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/aorta-v1.1.0.zip"
         },
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/aorta-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/aorta-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 60.0,
@@ -1357,7 +1357,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/icrh-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/icrh-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 21.7,
@@ -1379,7 +1379,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/anatomy_and_icrh-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/anatomy_and_icrh-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 40.1,
@@ -1431,7 +1431,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/brats-gli-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/brats-gli-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 32.4,
@@ -1470,7 +1470,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/brats-men-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/brats-men-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 36.2,
@@ -1509,7 +1509,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/brats-met-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/brats-met-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 39.5,
@@ -1548,7 +1548,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/brats-ped-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/brats-ped-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 42.0,
@@ -1587,7 +1587,7 @@
       ],
       "versions": [
         {
-          "url": "https://github.com/lassoan/SlicerMONAIAuto3DSeg/releases/download/Models/brats-ssa-v1.0.0.zip"
+          "url": "https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/download/Models/brats-ssa-v1.0.0.zip"
         }
       ],
       "segmentationTimeSecGPU": 43.2,

--- a/MONAIAuto3DSeg/Resources/Models.json
+++ b/MONAIAuto3DSeg/Resources/Models.json
@@ -306,8 +306,14 @@
       "description": "Model trained on CT scans for whole head segmentation.",
       "subject": "human",
       "imagingModality": "CT",
+      "inputs": [
+        {
+          "title": "Input volume",
+          "namePattern": "*CT*"
+        }
+      ],
       "sampleData": [
-        "CTBrain"
+        "CTMRBrain"
       ],
       "versions": [
         {
@@ -333,8 +339,14 @@
       "description": "Low-resolution (1mm) for quick preview. Model trained on CT scans for whole head segmentation.",
       "subject": "human",
       "imagingModality": "CT",
+      "inputs": [
+        {
+          "title": "Input volume",
+          "namePattern": "*CT*"
+        }
+      ],
       "sampleData": [
-        "CTBrain"
+        "CTMRBrain"
       ],
       "versions": [
         {

--- a/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
+++ b/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
@@ -32,6 +32,7 @@ from monai.transforms import (
     ConcatItemsd,
 )
 
+OPENVINO_DEFAULT_ON = True
 
 def logits2pred(logits, sigmoid=False, dim=1):
     if isinstance(logits, (list, tuple)):
@@ -97,7 +98,7 @@ def main(model_file,
     device = torch.device("cpu") if torch.cuda.device_count() == 0 else torch.device(0)
 
     enable_openvino = False
-    if device.type == 'cpu' and os.path.exists(model_file.replace('.pt', '.xml')):
+    if device.type == 'cpu' and os.path.exists(model_file.replace('.pt', '.xml')) and OPENVINO_DEFAULT_ON:
         print("OpenVINO Inference enabled")
         enable_openvino = True
 

--- a/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
+++ b/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
@@ -1,10 +1,12 @@
+import gc
 import os
 import numpy as np
 import fire
 import time
 import torch
 from collections import OrderedDict
-
+from functools import partial
+import openvino as ov
 import nrrd
 from monai.bundle import ConfigParser
 from monai.data import decollate_batch, list_data_collate
@@ -12,7 +14,7 @@ from monai.utils import convert_to_dst_type
 from monai.utils import MetaKeys
 
 from torch.cuda.amp import autocast
-from monai.inferers import SlidingWindowInfererAdapt
+from monai.inferers import SlidingWindowInfererAdapt, SlidingWindowInferer
 
 from monai.transforms import (
     Compose,
@@ -44,6 +46,28 @@ def logits2pred(logits, sigmoid=False, dim=1):
 
     return pred
 
+def overrides_fn(kwargs):
+    overrides = {
+        "overlap": 0.5
+    }
+    if "overlap" in kwargs:
+        overrides["overlap"] = kwargs["overlap"]
+    return overrides
+
+def openvino_infer(infer_request, input_tensor):
+    ov_input_tensor = ov.Tensor(array=np.ascontiguousarray(input_tensor.numpy()), shared_memory=False)
+    infer_request.set_input_tensor(ov_input_tensor)
+    infer_request.start_async()
+    infer_request.wait()
+    output_tensor = infer_request.get_output_tensor()
+    result = torch.from_numpy(output_tensor.data)
+    return result
+
+def configure_openvino(model_path):
+    core = ov.Core()
+    model = core.read_model(model_path)
+    compiled_model = core.compile_model(model, "AUTO")
+    return compiled_model
 
 @torch.no_grad()
 def main(model_file,
@@ -54,10 +78,12 @@ def main(model_file,
          image_file_3=None,
          image_file_4=None,
          **kwargs):
+
+    overrides = overrides_fn(kwargs)
+
+    print(f"Applying overrides: {overrides}")
     start_time = time.time()
     timing_checkpoints = []  # list of (operation, time) tuples
-
-    # Checking for model file
 
     if not os.path.exists(model_file):
         raise ValueError('Cannot find model file:' + str(model_file))
@@ -68,6 +94,12 @@ def main(model_file,
         raise ValueError('Config not found in checkpoint (not a auto3dseg/segresnet model):' + str(model_file))
 
     config = checkpoint["config"]
+    device = torch.device("cpu") if torch.cuda.device_count() == 0 else torch.device(0)
+
+    enable_openvino = False
+    if device.type == 'cpu' and os.path.exists(model_file.replace('.pt', '.xml')):
+        print("OpenVINO Inference enabled")
+        enable_openvino = True
 
     state_dict = checkpoint["state_dict"]
 
@@ -75,18 +107,22 @@ def main(model_file,
     best_metric = checkpoint.get("best_metric", 0)
     sigmoid = config.get("sigmoid", False)
 
-    model = ConfigParser(config["network"]).get_parsed_content()
-    model.load_state_dict(state_dict, strict=True)
+    # Checking for model file
+    
+    if enable_openvino:
+        del checkpoint
+        gc.collect()
+        model = configure_openvino(model_file.replace('.pt', '.xml'))
+    else:
+        model = ConfigParser(config["network"]).get_parsed_content()
+        model.load_state_dict(state_dict, strict=True)
+        model = model.to(device=device, memory_format=torch.channels_last_3d)  # gpu
+        model.eval()
 
     print(f'Model epoch {epoch} metric {best_metric}')
 
-    device = torch.device("cpu") if torch.cuda.device_count() == 0 else torch.device(0)
-    model = model.to(device=device, memory_format=torch.channels_last_3d)  # gpu
-    model.eval()
-
     # If BRATS
     if save_mode == 'brats' or 'brats' in model_file:  # for brats case
-
         image_files = []
         for index, img in enumerate([image_file, image_file_2, image_file_3, image_file_4]):
             if img is not None:
@@ -135,8 +171,9 @@ def main(model_file,
 
         # sliding_inferrer
         roi_size = config["roi_size"]
+
         # roi_size = [224, 224, 144]
-        sliding_inferrer = SlidingWindowInfererAdapt(roi_size=roi_size, sw_batch_size=1, overlap=0.625, mode="gaussian",
+        sliding_inferrer = SlidingWindowInfererAdapt(roi_size=roi_size, sw_batch_size=1, overlap=overrides["overlap"], mode="gaussian",
                                                      cache_roi_weight_map=False, progress=True)
 
         # process DATA
@@ -271,8 +308,9 @@ def main(model_file,
 
         # sliding_inferrer
         roi_size = config["roi_size"]
+
         # roi_size = [224, 224, 144]
-        sliding_inferrer = SlidingWindowInfererAdapt(roi_size=roi_size, sw_batch_size=1, overlap=0.625, mode="gaussian",
+        sliding_inferrer = SlidingWindowInfererAdapt(roi_size=roi_size, sw_batch_size=1, overlap=overrides["overlap"], mode="gaussian",
                                                      cache_roi_weight_map=False, progress=True)
 
         # process DATA
@@ -284,8 +322,16 @@ def main(model_file,
         timing_checkpoints.append(("Preprocessing", time.time()))
 
         print('Running Inference ...')
-        with autocast(enabled=True):
-            logits = sliding_inferrer(inputs=data, network=model)
+
+        if enable_openvino:
+            infer_request = model.create_infer_request()
+            logits = sliding_inferrer(inputs=data, network=lambda x: openvino_infer(infer_request, x))
+            del infer_request, model
+            gc.collect()
+        else:
+            with autocast(enabled=True):
+                logits = sliding_inferrer(inputs=data, network=model)
+
         timing_checkpoints.append(("Inference", time.time()))
 
         print(f"Logits {logits.shape}")


### PR DESCRIPTION
Following up here on some of the work I did at PW41 (https://projectweek.na-mic.org/PW41_2024_MIT/Projects/IntegrateCpuFriendlyAutoSegmentationAndCtUtilityModelsIntoMhub/)

The main idea would be to provide OpenVINO optimized models for each of the trained models provided in this repo. When run on CPU, these models would be fetched (which are half the size) and optimized inference would be run with the OpenVINO inference API. 

Sending this PR in early so we can discuss how to best integrate this. 

What I've done so far is:
1. Take every model url from `Models.json` and convert the `model.pt` to an OpenVINO `model.xml` and `model.bin`. These are for now repackaged among the zip files and hosted on my fork here: https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/Models The conversion script is rather simple and could be added to a Github action or so if needed. https://gist.github.com/surajpaib/74600da3c2ad4e983f4d5022301bf568

2. I've edited the inference script in the Slicer extension and run the OpenVINO inference using these models (code changes in the PR)

3. Ran the testing suite from the slicer extension (disabling the GPU). You can see the results here: https://github.com/surajpaib/SlicerMONAIAuto3DSeg/releases/ModelsTestResults
These might not be one to one comparisons with the previous (as I use a different CPU) so maybe these need to be re-run on the machine used for the original benchmark. On my machine, I see a speedup of between 1.5x to 2x. You can refer to the PW page where I put up some comparisons. 