### PR TITLE
Reduce memory usage by removing softmax in logits2pred()

### DIFF
--- a/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
+++ b/MONAIAuto3DSeg/Scripts/auto3dseg_segresnet_inference.py
@@ -39,8 +39,7 @@ def logits2pred(logits, sigmoid=False, dim=1):
         pred = torch.sigmoid(logits)
         pred = (pred >= 0.5)
     else:
-        pred = torch.softmax(logits, dim=dim)
-        pred = torch.argmax(pred, dim=dim, keepdim=True).to(dtype=torch.uint8)
+        pred = torch.argmax(logits, dim=dim, keepdim=True).to(dtype=torch.uint8)
 
     return pred
 


### PR DESCRIPTION
As mentioned in #92 removing `softmax()` don't affect current logic, but will greatly reduce memory usage especially when segmenting larger CT scans using the whole-body-v2.0.1.